### PR TITLE
Include nonce in CTR mode for increased security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "confy",
-  "version": "0.0.1",
+  "name": "confy-cli",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "confy",
-      "version": "0.0.1",
+      "name": "confy-cli",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "aes-js": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "confy-cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "src/encoder.js",
   "bin": {
     "confy": "src/encoder.js"

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -52,23 +52,23 @@ const usage = commandLineUsage(sections)
 const args = commandLineArgs(optionDefinitions);
 
 if (!args.input || !args.output || !args.key || args.help) {
-    console.log(usage)
-    process.exit(0)
+  console.log(usage)
+  process.exit(0)
 }
 
-function aes_from_key(key) {
+function aes_from_key(key, nonce) {
   if (key == null) key = "";
-  key = aesjs.utils.utf8.toBytes(key.padEnd(32, "0"))
-  return new aesjs.ModeOfOperation.ctr(key)
+  key = aesjs.utils.utf8.toBytes(key.padEnd(32, "\0"))
+  return new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(nonce))
 }
 
 JSDOM.fromFile(args.input).then(async dom => {
   var document = dom.window.document;
   Array.from(document.getElementsByClassName("secret")).forEach(x => {
-    var textBytes = aesjs.utils.utf8.toBytes(x.innerHTML)
-    var encrypted = aesjs.utils.hex.fromBytes(
-        aes_from_key(args.key).encrypt(textBytes)
-    );
+    const textBytes = aesjs.utils.utf8.toBytes(x.innerHTML)
+    const nonce = crypto.getRandomValues(new Uint8Array(16));
+    const encryptedBytes = aes_from_key(args.key, nonce).encrypt(textBytes)
+    const encrypted = aesjs.utils.hex.fromBytes(new Uint8Array([...nonce, ...encryptedBytes]));
     console.log(encrypted)
     x.innerHTML = encrypted
   });
@@ -78,15 +78,15 @@ JSDOM.fromFile(args.input).then(async dom => {
     var script = await index.text()
     document.body.appendChild(JSDOM.fragment(`<script>${script}</script>`))
   }
-  else { 
+  else {
     document.body.appendChild(
       JSDOM.fragment('<script src="https://cdn.rawgit.com/ricmoo/aes-js/e27b99df/index.js"></script>')
     )
   }
   const inject = fs.readFileSync(`${__dirname}/inject.js`, 'utf8')
   document.body.appendChild(JSDOM.fragment(`<script>${inject}</script>`))
-  
-  
+
+
   fs.writeFile(args.output, dom.serialize(), err => {
     if (err) {
       console.error(err);

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,13 +1,16 @@
-function aes_from_key(key) {
-  if (key == null) key = "";
-  key = aesjs.utils.utf8.toBytes(key.padEnd(32, "0"))
-  return new aesjs.ModeOfOperation.ctr(key)
+function aes_from_key(key, nonce) {
+    if (key == null) key = "";
+    key = aesjs.utils.utf8.toBytes(key.padEnd(32, "\0"))
+    return new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(nonce))
 }
 
 const key = new URLSearchParams(window.location.search).get("key")
 
 Array.from(document.getElementsByClassName('secret')).forEach(x => {
+    const content = x.innerHTML.trim();
+    const nonce = aesjs.utils.hex.toBytes(content.slice(0, 32));
+    const ciphertext = aesjs.utils.hex.toBytes(content.slice(32));
     x.innerHTML = aesjs.utils.utf8.fromBytes(
-        aes_from_key(key).decrypt(aesjs.utils.hex.toBytes(x.innerHTML.trim()))
+        aes_from_key(key, nonce).decrypt(ciphertext)
     );
 })


### PR DESCRIPTION
Including a random nonce value into encryption with CTR mode is highly advisable for security reasons. I altered the code so that nonce is appended to the beginning of ciphertext during encryption stage, and extracted during decryption stage accordingly. For more information about [nonce aka. initialization vector (IV)](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Initialization_vector_(IV)) check the linked wikipedia article.

This PR also includes version change, some formatting corrections and key padding change from `'0'` to `'\0'`.